### PR TITLE
Updated the podspec with missing attributes.

### DIFF
--- a/SimpleFrameworkObjc.podspec
+++ b/SimpleFrameworkObjc.podspec
@@ -78,7 +78,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/DashRobotics/simple-framework-objc.git" }
+  s.source       = { :git => "https://github.com/redlinesolutions/simple-framework-objc.git" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/SimpleFrameworkObjc.podspec
+++ b/SimpleFrameworkObjc.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.name         = "SimpleFrameworkObjc"
   s.version      = "0.0.4"
-  s.summary      = "A short description of SimpleFrameworkObjc."
+  s.summary      = "A simple framework."
 
   s.description  = <<-DESC
                    A longer description of SimpleFrameworkObjc in Markdown format.
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
                    * Finally, don't worry about the indent, CocoaPods strips it!
                    DESC
 
-  #s.homepage     = "http://EXAMPLE/SimpleFrameworkObjc"
+  s.homepage     = "https://github.com/redlinesolutions/simple-framework-objc"
   # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
 
 
@@ -78,7 +78,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  #s.source       = { :git => "http://EXAMPLE/SimpleFrameworkObjc.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/DashRobotics/simple-framework-objc.git" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #


### PR DESCRIPTION
CocoaPods 1.0.0.beta.6+ throws errors if the “homepage” or “source” attributes are missing, and warns if “summary” is unchanged.
