### PR TITLE
Prevent enumeration mutation error by copying array

### DIFF
--- a/SimpleFramework/SFWPublisher.m
+++ b/SimpleFramework/SFWPublisher.m
@@ -74,7 +74,8 @@ THE SOFTWARE.
     BOOL isRequired = ((NSNumber *)dict[@"required"]).boolValue;
 
     @synchronized (self) {
-        for (SFWWeakRef *observer in self.observers) {
+        NSArray *observers = [NSArray arrayWithArray:self.observers];
+        for (SFWWeakRef *observer in observers) {
             if (isRequired || [observer.value respondsToSelector:anInvocation.selector])
                 [anInvocation invokeWithTarget:observer.value];
         }


### PR DESCRIPTION
I'm getting a few "collection mutated while being enumerated" crashes down in SFWPublisherProxy.
Link: http://crashes.to/s/47e45f3c470

Obvious fix (?) is to copy the array before enumerating, so that's what I've done.
